### PR TITLE
fix :  (build.gradle)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,10 @@ android {
         jvmTarget = JavaVersion.VERSION_1_8
     }
 
+    kotlin.sourceSets.all {
+        it.languageSettings.enableLanguageFeature("DataObjects")
+    }
+
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
         test.java.srcDirs += "src/test/kotlin"


### PR DESCRIPTION
The feature "data objects" is only available since language version 1.9 error